### PR TITLE
Added matlab object saving

### DIFF
--- a/savejson.m
+++ b/savejson.m
@@ -159,6 +159,8 @@ elseif(isstruct(item))
     txt=struct2json(name,item,level,varargin{:});
 elseif(ischar(item))
     txt=str2json(name,item,level,varargin{:});
+elseif(isobject(item)) 
+    txt=matlabobject2json(name,item,level,varargin{:});
 else
     txt=mat2json(name,item,level,varargin{:});
 end
@@ -410,6 +412,23 @@ else
     end
 end
 txt=sprintf('%s%s%s',txt,padding1,'}');
+
+%%-------------------------------------------------------------------------
+function txt=matlabobject2json(name,item,level,varargin)
+if numel(item) == 0 %empty object
+    st = struct();
+else
+    % "st = struct(item);" would produce an inmutable warning, because it
+    % make the protected and private properties visible. Instead we get the
+    % visible properties
+    propertynames = properties(item);
+    for p = 1:numel(propertynames)
+        for o = numel(item):-1:1 % aray of objects
+            st(o).(propertynames{p}) = item(o).(propertynames{p});
+        end
+    end
+end
+txt=struct2json(name,st,level,varargin{:});
 
 %%-------------------------------------------------------------------------
 function txt=matdata2json(mat,level,varargin)


### PR DESCRIPTION
Since many people incorporate MATLAB classes, it would be useful to support saving the (public) properties of matlab objects. 

The code is tested for empty object, i.e. numel(obj) == 0; vector of objects. Currently, the code flattens 2D or higher dimensional array of objects to a vector.