### PR TITLE
Resolving bug that cell type is converted to json with transposed data

### DIFF
--- a/savejson.m
+++ b/savejson.m
@@ -197,20 +197,20 @@ elseif(len==0)
         txt=sprintf('%s[]',padding0); 
     end
 end
-for j=1:dim(2)
+for i=1:dim(1)
     if(dim(1)>1)
         txt=sprintf('%s%s[%s',txt,padding2,nl);
     end
-    for i=1:dim(1)
+    for j=1:dim(2)
        txt=sprintf('%s%s',txt,obj2json(name,item{i,j},level+(dim(1)>1)+(len>1),varargin{:}));
-       if(i<dim(1))
+       if(j<dim(2))
            txt=sprintf('%s%s',txt,sprintf(',%s',nl));
        end
     end
     if(dim(1)>1)
         txt=sprintf('%s%s%s]',txt,nl,padding2);
     end
-    if(j<dim(2))
+    if(i<dim(1))
         txt=sprintf('%s%s',txt,sprintf(',%s',nl));
     end
     %if(j==dim(2)) txt=sprintf('%s%s',txt,sprintf(',%s',nl)); end


### PR DESCRIPTION
# Problem
Saving 2D cell array resulted in transposed data in json string. 

Here is example. We save 2 by 3 cell array. Saving it to JSON, then loading the saved JSON string gives 3 by 2 array, which is unintended transposed data.

```matlab
mixed_cell = { 1, 2, 3;...
              4, 5, 6}; 
size(mixed_cell)
% ans =
%      2     3

str = savejson(mixed_cell)
% str =
% {
% 	"mixed_cell": [
% 		[
% 			1,
% 			4
% 		],
% 		[
% 			2,
% 			5
% 		],
% 		[
% 			3,
% 			6
% 		]
% 	]
% }

obj = loadjson(str)
% obj = 
%   mixed_cell: [3x2 double]
```



# Solution
I changed loop order in function cell2json in savejson.m file.

# Result

```matlab
mixed_cell = { 1, 2, 3;...
              4, 5, 6}; 
size(mixed_cell)
% ans =
%      2     3
str = savejson(mixed_cell)
% str =
% {
% 	"mixed_cell": [
% 		[
% 			1,
% 			2,
% 			3
% 		],
% 		[
% 			4,
% 			5,
% 			6
% 		]
% 	]
% }

obj = loadjson(str)
% obj = 
%    mixed_cell: [2x3 double]
```





