### PR TITLE
File path is wrongly inerpreted as JSON string

### DIFF
--- a/loadjson.m
+++ b/loadjson.m
@@ -63,7 +63,7 @@ function data = loadjson(fname,varargin)
 
 global pos inStr len  esc index_esc len_esc isoct arraytoken
 
-if(regexp(fname,'[\{\}\]\[]','once'))
+if(regexp(fname,'^\s*(?:\[.+\])|(?:\{.+\})\s*$','once'))
    string=fname;
 elseif(exist(fname,'file'))
    try


### PR DESCRIPTION
for example the following paths will be interpreted as JSON string:
- D:\project\some [folder] name\example.json
- C:\project\some {folder} name\example.json