### PR TITLE
Speedup of valid_field()

### DIFF
--- a/loadjson.m
+++ b/loadjson.m
@@ -416,7 +416,7 @@ function str = valid_field(str)
         outstr = cell(1,N);
         for ii = 1:N
             if iconvert(ii)
-                outstr{ii} = sprintf('_0x%x_',str(ii));
+                outstr{ii} = sprintf('_0x%X_',str(ii));
             else
                 outstr{ii} = str(ii);
             end
@@ -426,7 +426,9 @@ function str = valid_field(str)
             str(1) = 'x';
         end
     end
-    %str(~isletter(str) & ~('0' <= str & str <= '9')) = '_';
+    if isstrprop(str(1), 'digit')
+        str = [sprintf('x0x%X_',str(1)) str(2:end)];
+    end
 
 %%-------------------------------------------------------------------------
 function endpos = matching_quote(str,pos)

--- a/loadjson.m
+++ b/loadjson.m
@@ -410,32 +410,20 @@ function str = valid_field(str)
 % followed by any combination of letters, digits, and underscores.
 % Invalid characters will be converted to underscores, and the prefix
 % "x0x[Hex code]_" will be added if the first character is not a letter.
-    pos=regexp(str,'^[^A-Za-z]','once');
-    if(~isempty(pos))
-        if ~isOctave()
-            str=regexprep(str,'^([^A-Za-z])','x0x${sprintf(''%X'',unicode2native($1))}_','once');
-        else
-            str=sprintf('x0x%X_%s',char(str(1)),str(2:end));
+    iconvert = ~isfieldnamechar(str);
+    if any(iconvert)
+        N = numel(str);
+        outstr = cell(1,N);
+        for ii = 1:N
+            if iconvert(ii)
+                outstr{ii} = sprintf('_0x%x_',str(ii));
+            else
+                outstr{ii} = str(ii);
+            end
         end
-    end
-    if(isempty(regexp(str,'[^0-9A-Za-z_]', 'once' )))
-        return;
-    end
-    if ~isOctave()
-        str=regexprep(str,'([^0-9A-Za-z_])','_0x${sprintf(''%X'',unicode2native($1))}_');
-    else
-        pos=regexp(str,'[^0-9A-Za-z_]');
-        if(isempty(pos))
-            return;
-        end
-        str0=str;
-        pos0=[0 pos(:)' length(str)];
-        str='';
-        for i=1:length(pos)
-            str=[str str0(pos0(i)+1:pos(i)-1) sprintf('_0x%X_',str0(pos(i)))];
-        end
-        if(pos(end)~=length(str))
-            str=[str str0(pos0(end-1)+1:pos0(end))];
+        str = [outstr{:}];
+        if strcmp(str(1), '_')
+            str(1) = 'x';
         end
     end
     %str(~isletter(str) & ~('0' <= str & str <= '9')) = '_';

--- a/private/isOctave.m
+++ b/private/isOctave.m
@@ -1,0 +1,3 @@
+function bool = isOctave()
+bool = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+end

--- a/private/isOctave.m
+++ b/private/isOctave.m
@@ -1,3 +1,7 @@
 function bool = isOctave()
-bool = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+persistent tf
+if isempty(tf)
+    tf = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+end
+bool = tf;
 end

--- a/private/isfieldnamechar.m
+++ b/private/isfieldnamechar.m
@@ -1,0 +1,12 @@
+function tf = isfieldnamechar(str)
+% Returns a boolean array with true for characters that are admissable in a fieldname
+% See also: ISVARNAME
+
+% ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz
+validchars = [65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,95,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122];
+if isOctave()
+    tf = ismember(double(str), validchars);
+else
+    tf = ismembc(double(str), validchars);
+end
+end

--- a/private/isfieldnamechar.m
+++ b/private/isfieldnamechar.m
@@ -1,8 +1,13 @@
 function tf = isfieldnamechar(str)
-% Returns a boolean array with true for characters that are admissable in a fieldname
-% See also: ISVARNAME
+% True for characters that are allowed in a fieldname
+%
+%   TF = ISFIELDNAMECHAR(STR)
+%       STR must a row char array and returns a boolean array TF of the
+%       same size as STR with true for char that are allowed in a
+%       variable name.
+%
+% See also: ISSTRPROP, ISVARNAME
 
 % ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz
-% validchars = [65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,95,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122];
-tf = (str > 64 & str < 91) | str == 95 | (str > 96 & str < 123);
+tf = isstrprop(str,'alphanum') | str == '_';
 end

--- a/private/isfieldnamechar.m
+++ b/private/isfieldnamechar.m
@@ -3,10 +3,6 @@ function tf = isfieldnamechar(str)
 % See also: ISVARNAME
 
 % ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz
-validchars = [65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,95,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122];
-if isOctave()
-    tf = ismember(double(str), validchars);
-else
-    tf = ismembc(double(str), validchars);
-end
+% validchars = [65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,95,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122];
+tf = (str > 64 & str < 91) | str == 95 | (str > 96 & str < 123);
 end


### PR DESCRIPTION
Dropping the `unicode2native()` since Matlab uses the first 65536 unicode points internally (see  http://uk.mathworks.com/matlabcentral/answers/63980-how-to-access-unicode-strings-through-mex-engine-c-interfaces)

Also, caching isOctave() into a private function, which would eventually help to disentangle things in the future (i.e. drop global variables) and gain more speedup.

On my system valid_field() executes in about 4 seconds instead of 20, i.e. a 5x speedup.
