### PR TITLE
Fix field prefix computation in function valid_field (Octave 4.0.0)

### DIFF
--- a/loadjson.m
+++ b/loadjson.m
@@ -417,7 +417,7 @@ global isoct
         if(~isoct)
             str=regexprep(str,'^([^A-Za-z])','x0x${sprintf(''%X'',unicode2native($1))}_','once');
         else
-            str=sprintf('x0x%X_%s',char(str(1)),str(2:end));
+            str=sprintf('x0x%X_%s',toascii(str(1)),str(2:end));
         end
     end
     if(isempty(regexp(str,'[^0-9A-Za-z_]', 'once' )))
@@ -434,7 +434,7 @@ global isoct
         pos0=[0 pos(:)' length(str)];
         str='';
         for i=1:length(pos)
-            str=[str str0(pos0(i)+1:pos(i)-1) sprintf('_0x%X_',str0(pos(i)))];
+            str=[str str0(pos0(i)+1:pos(i)-1) sprintf('_0x%X_',toascii(str0(pos(i))))];
         end
         if(pos(end)~=length(str))
             str=[str str0(pos0(end-1)+1:pos0(end))];

--- a/loadjson.m
+++ b/loadjson.m
@@ -494,3 +494,13 @@ end
 if(endpos==0) 
     error('unmatched "]"');
 end
+
+%!assert ( loadjson('[1]'), 1 )
+%!assert ( loadjson('[1, 2]'), [1, 2] )
+
+%!assert ( loadjson('["a"]'),  cellstr("a") )
+%!assert ( loadjson('["a", "b"]'),  cellstr(["a"; "b"])' )
+
+%!assert ( loadjson('{"a":1}'), struct("a", 1) )
+%!assert ( loadjson('{"a":"b"}'), struct("a", "b") )
+%!assert ( loadjson('{"1":"2"}'), struct("x0x31_", "2") )


### PR DESCRIPTION
According to https://learner.coursera.help/hc/en-us/community/posts/204693179-linear-regression-submit-error, jsonlab is broken in Octave 4.0.0

I created a test that shows the problem: function valid_field outputs the character code as decimal digits and not hexadecimal. For example, "1" should be encoded as 0x31 and not 0x49.

I fixed this the way Jacob Middag suggested on the linked website.
## Before

```
>> test loadjson
***** assert ( loadjson('{"1":"2"}'), struct("x0x31_", "2") )
!!!!! test failed
ASSERT errors for:  assert (loadjson ('{"1":"2"}'),struct ("x0x31_", "2"))

  Location  |  Observed  |  Expected  |  Reason
     .            O            E         'x0x49_' is not an expected field
     .            O            E         Structure configuration error
```
## After

```
>> test loadjson
PASSES 7 out of 7 tests
```
