### PR TITLE
respect integer types

### DIFF
--- a/savejson.m
+++ b/savejson.m
@@ -468,7 +468,11 @@ if(isempty(mat))
     txt='null';
     return;
 end
-floatformat=jsonopt('FloatFormat','%.10g',varargin{:});
+if(isinteger(mat))
+  floatformat=jsonopt('FloatFormat','%d',varargin{:});
+else
+  floatformat=jsonopt('FloatFormat','%.10g',varargin{:});
+end
 %if(numel(mat)>1)
     formatstr=['[' repmat([floatformat ','],1,size(mat,2)-1) [floatformat sprintf('],%s',nl)]];
 %else


### PR DESCRIPTION
When integer values are saved into a json document they are always treated as float:
```matlab
>> a = [ int64(1487075890726396) int64(1487075890726397) ]
a =

  1487075890726396  1487075890726397

>> savejson(a)
ans = {
        "a": [1.487075891e+15,1.487075891e+15]
}
```

Was this intended?

This patch fixes this by using integer format. It may be even better to add an option for IntFormat.