### PR TITLE
support for string class  …

### DIFF
--- a/savejson.m
+++ b/savejson.m
@@ -169,7 +169,7 @@ if(iscell(item))
     txt=cell2json(name,item,level,varargin{:});
 elseif(isstruct(item))
     txt=struct2json(name,item,level,varargin{:});
-elseif(ischar(item))
+elseif (ischar(item)) || (isstring(item))
     txt=str2json(name,item,level,varargin{:});
 elseif(isobject(item)) 
     txt=matlabobject2json(name,item,level,varargin{:});
@@ -310,7 +310,7 @@ txt = sprintf('%s',txt{:});
 %%-------------------------------------------------------------------------
 function txt=str2json(name,item,level,varargin)
 txt={};
-if(~ischar(item))
+if ~(ischar(item) || isstring(item))
         error('input is not a string');
 end
 item=reshape(item, max(size(item),[1 0]));


### PR DESCRIPTION
My string in a cell is loaded as string class not a char class in MATLAB R2017a
use isstring with ischar to solve this issue