### PR TITLE
Add Encoding option to loadjson and savejson

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -188,7 +188,9 @@ JSON. The detailed help info for the four functions can be found below:
             opt.ShowProgress [0|1]: if set to 1, loadjson displays a progress bar.
             opt.ParseStringArray [0|1]: if set to 0, loadjson converts "string arrays" 
                           (introduced in MATLAB R2016b) to char arrays; if set to 1,
-                          loadjson skips this conversion. 
+                          loadjson skips this conversion.
+            opt.Encoding ['']: json file encoding. Support all encodings of
+                          fopen() function
 
   output:
        dat: a cell array, where {...} blocks are converted into cell arrays,
@@ -289,6 +291,9 @@ JSON. The detailed help info for the four functions can be found below:
                               compressed binary array data. 
          opt.CompressArraySize [100|int]: only to compress an array if the total 
                           element count is larger than this number.
+         opt.Encoding ['']: json file encoding. Support all encodings of
+                          fopen() function
+
          opt can be replaced by a list of ('param',value) pairs. The param 
          string is equivallent to a field in opt and is case sensitive.
   output:

--- a/loadjson.m
+++ b/loadjson.m
@@ -53,6 +53,8 @@ function data = loadjson(fname,varargin)
 %                         for output format, it is incompatible with all
 %                         previous releases; if old output is desired,
 %                         please set FormatVersion to 1.9 or earlier.
+%           opt.Encoding ['']: json file encoding. Support all encodings of
+%                         fopen() function
 %
 % output:
 %      dat: a cell array, where {...} blocks are converted into cell arrays,
@@ -69,11 +71,20 @@ function data = loadjson(fname,varargin)
 % -- this function is part of JSONLab toolbox (http://iso2mesh.sf.net/cgi-bin/index.cgi?jsonlab)
 %
 
+    opt=varargin2struct(varargin{:});
+    
     if(regexp(fname,'^\s*(?:\[.*\])|(?:\{.*\})\s*$','once'))
        string=fname;
     elseif(exist(fname,'file'))
        try
-           string = fileread(fname);
+           encoding = jsonopt('Encoding','',opt);
+           if(isempty(encoding))
+               string = fileread(fname);
+           else
+               fid = fopen(fname,'r','n',encoding);
+               string = fread(fid,'*char')';
+               fclose(fid);
+           end
        catch
            try
                string = urlread(['file://',fname]);
@@ -93,7 +104,6 @@ function data = loadjson(fname,varargin)
     esc = find(inputstr=='"' | inputstr=='\' ); % comparable to: regexp(inputstr, '["\\]');
     index_esc = 1;
 
-    opt=varargin2struct(varargin{:});
     opt.arraytoken_=arraytoken;
     opt.arraytokenidx_=arraytokenidx;
 

--- a/savejson.m
+++ b/savejson.m
@@ -200,16 +200,16 @@ end
 filename=jsonopt('FileName','',opt);
 if(~isempty(filename))
     if(jsonopt('SaveBinary',0,opt)==1)
-	    fid = fopen(filename, 'wb');
-	    fwrite(fid,json);
+        fid = fopen(filename, 'wb');
+        fwrite(fid,json);
     else
-	    encoding = jsonopt('Encoding','',opt);
+        encoding = jsonopt('Encoding','',opt);
         if(isempty(encoding))
             fid = fopen(filename,'wt');
         else
             fid = fopen(filename,'wt','n',encoding);
         end
-	    fwrite(fid,json,'char');
+        fwrite(fid,json,'char');
     end
     fclose(fid);
 end

--- a/savejson.m
+++ b/savejson.m
@@ -88,6 +88,8 @@ function json=savejson(rootname,obj,varargin)
 %                         for output format, it is incompatible with all
 %                         previous releases; if old output is desired,
 %                         please set FormatVersion to 1.9 or earlier.
+%        opt.Encoding ['']: json file encoding. Support all encodings of
+%                         fopen() function
 %
 %        opt can be replaced by a list of ('param',value) pairs. The param 
 %        string is equivallent to a field in opt and is case sensitive.
@@ -201,7 +203,12 @@ if(~isempty(filename))
 	    fid = fopen(filename, 'wb');
 	    fwrite(fid,json);
     else
-	    fid = fopen(filename, 'wt');
+	    encoding = jsonopt('Encoding','',opt);
+        if(isempty(encoding))
+            fid = fopen(filename,'wt');
+        else
+            fid = fopen(filename,'wt','n',encoding);
+        end
 	    fwrite(fid,json,'char');
     end
     fclose(fid);


### PR DESCRIPTION
Hi, I faced a problem with UTF-8 json files containing Russian letters, so I added an `Encoding` option to `loadjson` and `savejson` to successfully work with them. Example:
```MATLAB
data = loadjson('file.json', 'Encoding', 'UTF-8');
savejson('', data, 'FileName', 'file.json', 'Encoding', 'UTF-8');
```
I think this will help many people.

P.S. Thank you for this library!