### PR TITLE
Update package.json license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/fangq/jsonlab.git"
   },
   "author": "Qianqian Fang <q.fang at neu.edu>",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-only OR BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/fangq/jsonlab/issues"
   },


### PR DESCRIPTION
Make it match the included LICENSE files. Changed `GPL-3.0` to `GPL-3.0-only`  as the `GPL-3.0` identifier is deprecated (see https://spdx.org/licenses/)