### PR TITLE
Add handling for `null` JSON values

### DIFF
--- a/JsonNull.m
+++ b/JsonNull.m
@@ -1,0 +1,6 @@
+classdef JsonNull
+    %JSONNULL The class does nothing. It simply represents a null value in
+    %a json object..
+   
+end
+

--- a/jdataencode.m
+++ b/jdataencode.m
@@ -118,6 +118,8 @@ elseif(isa(item,'table'))
     newitem=table2jd(item,varargin{:});
 elseif(isa(item,'digraph') || isa(item,'graph'))
     newitem=graph2jd(item,varargin{:});
+elseif(isa(item, 'JsonNull'))
+    newitem=item;
 elseif(isobject(item))
     newitem=matlabobject2jd(item,varargin{:});
 else

--- a/loadjson.m
+++ b/loadjson.m
@@ -558,7 +558,7 @@ function varargout = parse_value(inputstr, pos, esc, index_esc, varargin)
             end
         case 'n'
             if pos+3 <= len && strcmpi(inputstr(pos:pos+3), 'null')
-                varargout{1} = [];
+                varargout{1} = JsonNull;
                 varargout{2} = pos + 4;
                 return;
             end

--- a/savejson.m
+++ b/savejson.m
@@ -301,6 +301,8 @@ elseif (isa(item, 'table'))
     txt = matlabtable2json(name, item, level, varargin{:});
 elseif (isa(item, 'graph') || isa(item, 'digraph'))
     txt = struct2json(name, jdataencode(item), level, varargin{:});
+elseif (isa(item, "JsonNull"))
+    txt = null2json(name, level, varargin{:});
 elseif (isobject(item))
     txt = matlabobject2json(name, item, level, varargin{:});
 else
@@ -512,6 +514,18 @@ txt(end + 1:end + 3) = {nl, padding0, '}'};
 txt = sprintf('%s', txt{:});
 
 %% -------------------------------------------------------------------------
+function txt = null2json(name, level, varargin)
+txt = {};
+ws = varargin{1}.whitespaces_;
+padding1 = repmat(ws.tab, 1, level);
+
+obj = ['"' decodevarname(name, varargin{1}.unpackhex) '": null'];
+if (isempty(name))
+    obj = 'null';
+end
+txt(end + 1:end + 2) = {padding1, obj};
+txt = sprintf('%s', txt{:});
+
 function txt = str2json(name, item, level, varargin)
 txt = {};
 if (~ischar(item))


### PR DESCRIPTION
This PR adds a `JsonNull` class which acts as a representation of JSON null values. `savejson` will convert `JsonNull` values to text that says `null` and `loadjson` will convert text that says `null` to an instance of `JsonNull`. An exception is added to `jdataencode` so that the `JsonNull` values will not be encoded to a struct in the same way that other objects are.

The following round-trip test will now succeed:
```
savejson('', loadjson('{"EmptyArray": [], "NullValue": null}'))

ans =

    '{
     	"EmptyArray":[],
     	"NullValue": null
     }
     '
```