### PR TITLE
Fix typos found by codespell

### DIFF
--- a/jdatadecode.m
+++ b/jdatadecode.m
@@ -44,7 +44,7 @@ function newdata=jdatadecode(data,varargin)
 %                         please set FormatVersion to 1
 %
 % output:
-%      newdata: the covnerted data if the input data does contain a JData 
+%      newdata: the converted data if the input data does contain a JData 
 %               structure; otherwise, the same as the input.
 %
 % examples:

--- a/jload.m
+++ b/jload.m
@@ -18,7 +18,7 @@ function varargout=jload(filename, varargin)
 %           JSON/JData file will be expected; if the suffix is '.pmat' or
 %           '.jdb', a Binary JData file will be expected.
 %      opt: (optional) a struct to store parsing options, opt can be replaced by 
-%           a list of ('param',value) pairs - the param string is equivallent
+%           a list of ('param',value) pairs - the param string is equivalent
 %           to a field in opt. opt can have the following 
 %           fields (first in [.|.] is the default)
 %

--- a/jsave.m
+++ b/jsave.m
@@ -16,7 +16,7 @@ function varargout=jsave(filename, varargin)
 %           JSON/JData file will be created (slow); if the suffix is '.pmat' or
 %           '.jdb', a Binary JData (https://github.com/NeuroJSON/bjdata/) file will be created.
 %      opt: (optional) a struct to store parsing options, opt can be replaced by 
-%           a list of ('param',value) pairs - the param string is equivallent
+%           a list of ('param',value) pairs - the param string is equivalent
 %           to a field in opt. opt can have the following 
 %           fields (first in [.|.] is the default)
 %

--- a/loadbj.m
+++ b/loadbj.m
@@ -21,7 +21,7 @@ function [data, mmap] = loadbj(fname,varargin)
 %      fname: input file name, if fname contains "{}" or "[]", fname
 %             will be interpreted as a BJData/UBJSON string
 %      opt: a struct to store parsing options, opt can be replaced by 
-%           a list of ('param',value) pairs - the param string is equivallent
+%           a list of ('param',value) pairs - the param string is equivalent
 %           to a field in opt. opt can have the following 
 %           fields (first in [.|.] is the default)
 %

--- a/loadjson.m
+++ b/loadjson.m
@@ -22,7 +22,7 @@ function [data, mmap] = loadjson(fname,varargin)
 %      fname: input file name; if fname contains "{}" or "[]", fname
 %             will be interpreted as a JSON string
 %      opt: (optional) a struct to store parsing options, opt can be replaced by 
-%           a list of ('param',value) pairs - the param string is equivallent
+%           a list of ('param',value) pairs - the param string is equivalent
 %           to a field in opt. opt can have the following 
 %           fields (first in [.|.] is the default)
 %

--- a/loadubjson.m
+++ b/loadubjson.m
@@ -16,7 +16,7 @@ function varargout = loadubjson(varargin)
 %             be read, otherwise, this function will attempt to parse the
 %             string in fname as a UBJSON stream
 %      opt: a struct to store parsing options, opt can be replaced by 
-%           a list of ('param',value) pairs - the param string is equivallent
+%           a list of ('param',value) pairs - the param string is equivalent
 %           to a field in opt. The supported options can be found by typing
 %           "help loadbj".
 %

--- a/savebj.m
+++ b/savebj.m
@@ -131,7 +131,7 @@ function output=savebj(rootname,obj,varargin)
 %                         the input data before saving
 %
 %        opt can be replaced by a list of ('param',value) pairs. The param 
-%        string is equivallent to a field in opt and is case sensitive.
+%        string is equivalent to a field in opt and is case sensitive.
 % output:
 %      bjd: a binary string in the UBJSON format (see http://ubjson.org)
 %

--- a/savejson.m
+++ b/savejson.m
@@ -110,7 +110,7 @@ function output = savejson(rootname, obj, varargin)
 %                         this function falls back to the jsonlab savejson
 %
 %        opt can be replaced by a list of ('param',value) pairs. The param
-%        string is equivallent to a field in opt and is case sensitive.
+%        string is equivalent to a field in opt and is case sensitive.
 % output:
 %      json: a string in the JSON format (see http://json.org)
 %

--- a/saveubjson.m
+++ b/saveubjson.m
@@ -38,7 +38,7 @@ function ubj=saveubjson(rootname,obj,varargin)
 %           opt can have the following fields (first in [.|.] is the default)
 %
 %           opt can be replaced by a list of ('param',value) pairs. The param 
-%           string is equivallent to a field in opt and is case sensitive.
+%           string is equivalent to a field in opt and is case sensitive.
 %
 %           Please type "help savebj" for details for all supported options.
 %


### PR DESCRIPTION
I guess the compati**bli**ty typo is from Mathworks and should not be fixed here:

https://github.com/fangq/jsonlab/blob/7d7e7f77e9754721146fe90f7ece1b910c3e0bc7/jsonlab.prj#L44-L47